### PR TITLE
feat: implemented UTC timezone for calendars

### DIFF
--- a/crates/caldav-utils/src/caldav/calendar.rs
+++ b/crates/caldav-utils/src/caldav/calendar.rs
@@ -16,15 +16,23 @@ pub struct Calendar {
     pub path: String,
 
     pub display_name: String,
+    pub timezone: Option<String>,
 }
 
 impl Calendar {
-    pub fn new(client: DavClient, url: Url, path: String, display_name: String) -> Calendar {
+    pub fn new(
+        client: DavClient,
+        url: Url,
+        path: String,
+        display_name: String,
+        timezone: Option<String>,
+    ) -> Calendar {
         Calendar {
             client,
             url,
             path,
             display_name,
+            timezone,
         }
     }
 

--- a/crates/caldav-utils/src/caldav/principal.rs
+++ b/crates/caldav-utils/src/caldav/principal.rs
@@ -21,9 +21,10 @@ static HOMESET_BODY: &str = r#"
 "#;
 
 static CALENDAR_BODY: &str = r#"
-    <d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" >
+    <d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ical="http://apple.com/ns/ical/" >
        <d:prop>
          <d:displayname />
+         <ical:calendar-timezone />
          <d:resourcetype />
          <c:supported-calendar-component-set />
        </d:prop>
@@ -126,6 +127,10 @@ impl Principal {
                     return None;
                 }
 
+                let timezone = find_element(response, "calendar-timezone".to_string())
+                    .expect("failed to find calendar-timezone")
+                    .text();
+
                 let href = find_element(response, "href".to_string())
                     .expect("failed to find href")
                     .text();
@@ -135,6 +140,7 @@ impl Principal {
                     self.url.clone(),
                     href,
                     displayname,
+                    Some(timezone),
                 ))
             })
             .collect();
@@ -231,6 +237,7 @@ impl Principal {
             // TODO: this is wrong, need to get the href from the response
             url,
             calendar_name.to_string(),
+            Some("UTC".to_string()),
         ))
     }
 }

--- a/crates/caldav-utils/src/tests.rs
+++ b/crates/caldav-utils/src/tests.rs
@@ -9,12 +9,6 @@ fn build_event(
 ) -> icalendar::Event {
     let mut event = icalendar::Event::new();
 
-    // because calendar timezones are not supported, we need to convert the start and end times to
-    // US/Central time as the library assumes that is the timezone of the calendar.
-    let timezone = chrono_tz::US::Central;
-    let start = start.with_timezone(&timezone);
-    let end = end.with_timezone(&timezone);
-
     let start_str = format!("{}", start.format(DATETIME));
     let end_str = format!("{}", end.format(DATETIME));
 
@@ -51,7 +45,7 @@ fn build_matrix_test(
     let calendar = build_calendar(events);
     let event = Event::new(calendar);
 
-    let matrix = get_event_matrix(range_start, range_end, granularity, &event);
+    let matrix = get_event_matrix(range_start, range_end, granularity, &event, None);
 
     matrix
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,9 +29,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let dav_client = DavClient::new(url.to_string(), credentials);
 
+    let availability_calendar =
+        std::env::var("AVAILABLE_CALENDAR").expect("AVAILABLE_CALENDAR not set");
+    let booked_calendar = std::env::var("BOOKED_CALENDAR").expect("BOOKED_CALENDAR not set");
+
     let caldav_state = CaldavAvailability::new(
-        "meeting_availability".to_string(),
-        "meeting_booked".to_string(),
+        availability_calendar.to_string(),
+        booked_calendar.to_string(),
         dav_client,
     );
 
@@ -68,6 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let mut principal = caldav_state.davclient().get_principal(&client).await?;
                     let calendar = principal.get_calendar(&client, &list.name).await?;
                     let events = calendar.get_events(&client, list.start, list.end).await?;
+                    tracing::info!("Found {} events", events.len());
                     for event in events {
                         tracing::info!("event: {:?}", event);
                     }


### PR DESCRIPTION
- Creating calendars is done in UTC
- No support for calendars in other timezones, but if they have the timezone in their properties then it should be fairly simple to add
- Calendar names are now determined via env